### PR TITLE
Whitelisting “file://“ Origin for Bridge

### DIFF
--- a/src/BlueSnapEncrypter.js
+++ b/src/BlueSnapEncrypter.js
@@ -5,104 +5,108 @@ import { View, WebView, StyleSheet } from "react-native";
 const BRIDGE = require("./bridge.html");
 const validTypes = ["encrypt"];
 const requests = {};
-const guid = () => Math.random().toString(36).slice(2);
+const guid = () =>
+  Math.random()
+    .toString(36)
+    .slice(2);
 const createAction = (type, data) => ({
-    _id: guid(),
-    type,
-    data
+  _id: guid(),
+  type,
+  data
 });
-const createRequest = (action) => {
-    return new Promise((resolve, reject) => {
-        requests[action._id] = {
-            resolve, reject, action
-        }
-    });
-}
+const createRequest = action => {
+  return new Promise((resolve, reject) => {
+    requests[action._id] = {
+      resolve,
+      reject,
+      action
+    };
+  });
+};
 const styles = StyleSheet.create({
-    container: {
-        width: 0,
-        height: 0,
-        display: "none"
-    }
+  container: {
+    width: 0,
+    height: 0,
+    display: "none"
+  }
 });
 
 export default class BlueSnapEncrypter extends PureComponent {
-    constructor(props, context) {
-        super(props, context);
+  constructor(props, context) {
+    super(props, context);
 
-        this.webView = null;
-        this.setWebViewRef = this.setWebViewRef.bind(this);
-        this.encrypt = this.encrypt.bind(this);
-        this.onEncrypt = this.onEncrypt.bind(this);
-        this.onMessage = this.onMessage.bind(this);
+    this.webView = null;
+    this.setWebViewRef = this.setWebViewRef.bind(this);
+    this.encrypt = this.encrypt.bind(this);
+    this.onEncrypt = this.onEncrypt.bind(this);
+    this.onMessage = this.onMessage.bind(this);
+  }
+
+  setWebViewRef(webView) {
+    this.webView = webView;
+  }
+
+  getInjectedJavaScript() {
+    const { bluesnapVersion, clientEncryptionKey, fraudSessionId } = this.props;
+
+    return `window.initialize("${clientEncryptionKey}", "${bluesnapVersion}", "${fraudSessionId}");`;
+  }
+
+  onEncrypt(action) {
+    const request = requests[action._id];
+
+    if (request) {
+      request.resolve(action.data);
+      delete requests[action._id];
     }
+  }
 
-    setWebViewRef(webView) {
-        this.webView = webView;
+  onMessage(event) {
+    try {
+      const action = JSON.parse(event.nativeEvent.data);
+      if (!action.type || !validTypes.includes(action.type)) {
+        return;
+      }
+
+      switch (action.type) {
+        case "encrypt":
+          this.onEncrypt(action);
+          break;
+      }
+    } catch (e) {
+      console.log("Error in onMessage of encrypter:", e);
     }
+  }
 
-    getInjectedJavaScript() {
-        const { bluesnapVersion, clientEncryptionKey, fraudSessionId } = this.props;
-
-        return `window.initialize("${clientEncryptionKey}", "${bluesnapVersion}", "${fraudSessionId}");`;
+  encrypt(data) {
+    if (this.webView) {
+      const action = createAction("encrypt", data);
+      this.webView.postMessage(JSON.stringify(action), "*");
+      return createRequest(action);
     }
+  }
 
-    onEncrypt(action) {
-        const request = requests[action._id];
-
-        if (request) {
-            request.resolve(action.data);
-            delete requests[action._id];
-        }
-    }
-
-    onMessage(event) {
-        try {
-            const action = JSON.parse(event.nativeEvent.data);
-
-            if (!action.type || !validTypes.includes(action.type)) {
-                return;
-            }
-
-            switch (action.type) {
-                case "encrypt":
-                    this.onEncrypt(action);
-                    break;
-            }
-        } catch (e) {
-
-        }
-    }
-
-    encrypt(data) {
-        if (this.webView) {
-            const action = createAction("encrypt", data);
-            this.webView.postMessage(JSON.stringify(action), "*");
-            return createRequest(action);
-        }
-    }
-
-    render() {
-        return (
-            <View style={styles.container}>
-                <WebView
-                    ref={this.setWebViewRef}
-                    onMessage={this.onMessage}
-                    injectedJavaScript={this.getInjectedJavaScript()}
-                    source={BRIDGE}
-                    originWhitelist={["file://"]}
-                />
-            </View>
-        );
-    }
+  render() {
+    return (
+      <View style={styles.container}>
+        <WebView
+          ref={this.setWebViewRef}
+          onMessage={this.onMessage}
+          injectedJavaScript={this.getInjectedJavaScript()}
+          source={BRIDGE}
+          originWhitelist={["*"]}
+        />
+      </View>
+    );
+  }
 }
 
 BlueSnapEncrypter.propTypes = {
-    clientEncryptionKey: PropTypes.string.isRequired,
-    bluesnapVersion: PropTypes.string
-}
+  clientEncryptionKey: PropTypes.string.isRequired,
+  bluesnapVersion: PropTypes.string
+};
 
 BlueSnapEncrypter.defaultProps = {
-    bluesnapVersion: "1.0.3",
-    fraudSessionId: ""
-}
+  bluesnapVersion: "1.0.3",
+  fraudSessionId: ""
+};

--- a/src/BlueSnapEncrypter.js
+++ b/src/BlueSnapEncrypter.js
@@ -90,6 +90,7 @@ export default class BlueSnapEncrypter extends PureComponent {
                     onMessage={this.onMessage}
                     injectedJavaScript={this.getInjectedJavaScript()}
                     source={BRIDGE}
+                    originWhitelist={["file://"]}
                 />
             </View>
         );


### PR DESCRIPTION
Hello and thank you for publishing this component!

I ran into a problem using the Encrypter today when I transitioned from running an app in local development to deploying the app.  I was met with the error:

`Unable to open URL: file:///var/mobile/Containers/Data/Application/___identifier___/Library/Application%20Support/CodePush/___another identifier___/CodePush/assets/node_modules/react-native-bluesnap-encrypter/src/bridge.html`

After inspecting the file system, I found that the bridge HTML file was in the right spot per the above.  A quick check of the docs turned up the solution; `WebView`s accept an [`originWhitelist` prop](https://facebook.github.io/react-native/docs/webview#originwhitelist) which selectively allows initial URLs to load.  The `file://` prefix is not in the defaults and must be added for the React component to be permitted to open the bridge file.  So, there is just one minuscule change!